### PR TITLE
Add proper Usage action handling to ensure proper help message

### DIFF
--- a/view
+++ b/view
@@ -114,7 +114,7 @@ function date_view() {
     option=$1
 
     #  Get today
-    today=$(date -d $(date +%Y-%m-%d) +%s)
+    today=$(gdate -d $(gdate +%Y-%m-%d) +%s)
 
     #  For each date show header and the list of todo items
     for date in $DATES ; do
@@ -150,7 +150,7 @@ function date_check() {
     # Assign variables
     threshold=$1
     today=$2
-    _date=$(date -d "$3" +%s)
+    _date=$(gdate -d "$3" +%s)
 
     # Check if the date is valid or not
     # return:
@@ -217,7 +217,7 @@ if [[ "$option" =~ $re ]]; then
     *)
         re="^(date|nodate|future|past)$"
         if [[ ! ( "$option" =~ $re ) ]]; then
-            option=$(date -d $(date -d $option +%Y-%m-%d) +%s)
+            option=$(gdate -d $(gdate -d $option +%Y-%m-%d) +%s)
         fi
 
         date_view $option

--- a/view
+++ b/view
@@ -193,6 +193,14 @@ function date_check() {
     return 0
 }
 
+[ "$action" = "usage" ] && {
+  echo "  View todos:"
+  echo "    view"
+  echo "      Groups and outputs tasks by various dimensions like projects, contextes, etc."
+  echo ""
+  exit
+}
+
 # Validate the input options
 re="^(help|project|context|date|nodate|future|past|today|tomorrow|yesterday|([+-][0-9]+|[0-9]+)(days|weeks|months|years))$"
 if [[ "$option" =~ $re ]]; then


### PR DESCRIPTION
Without this change, todo.sh -h outputs empty line instead of plugin name in the list.

```
  Actions can be added and overridden using scripts in the actions
  directory.
  Add-on Actions:
    birdseye
    view

  See "help" for more details.
```

In the example above, there would be empty line instead of "view"